### PR TITLE
chore: improve zeroPods alert configuration

### DIFF
--- a/charts/motive-cache/Chart.yaml
+++ b/charts/motive-cache/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.8
+version: 0.1.9
 
 appVersion: "1.0.0"

--- a/charts/motive-cache/README.md
+++ b/charts/motive-cache/README.md
@@ -1,6 +1,6 @@
 # motive-cache
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/motive-cache/templates/prometheus-rule-alerting.yaml
+++ b/charts/motive-cache/templates/prometheus-rule-alerting.yaml
@@ -42,6 +42,7 @@ spec:
             description: 'Service reports having not enough pods to ensure High Availability'
         {{- end }}
 
+        {{- if gt (.Values.replicas | int) 0 }}
         - alert: ZeroPods-{{ include "motive-cache.fullname" . }}
           expr: sum(kube_pod_status_ready{namespace="{{ $.Release.Namespace }}", pod=~"{{ include "motive-cache.fullname" . }}-.+", condition="true"}) == 0
           for: 0m
@@ -59,6 +60,7 @@ spec:
           annotations:
             summary: 'Number of Pods == 0'
             description: 'Service reports no pods running'
+          {{- end }}
 
         - alert: MemoryUsageMoreThan80Percent-{{ include "motive-cache.fullname" . }}
           expr: 100 * (varnish_sma_g_bytes{namespace="{{ $.Release.Namespace }}", pod=~"{{ include "motive-cache.fullname" . }}-.+"} / varnish_sma_g_space{namespace="{{ $.Release.Namespace }}", pod=~"{{ include "motive-cache.fullname" . }}-.+"}) > 80

--- a/charts/motive-service/Chart.yaml
+++ b/charts/motive-service/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 2.2.3
+version: 2.2.4
 
 appVersion: "1.0.0"

--- a/charts/motive-service/README.md
+++ b/charts/motive-service/README.md
@@ -1,6 +1,6 @@
 # motive-service
 
-![Version: 2.2.2](https://img.shields.io/badge/Version-2.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 2.2.4](https://img.shields.io/badge/Version-2.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/motive-service/templates/prometheus-rule-alerting.yaml
+++ b/charts/motive-service/templates/prometheus-rule-alerting.yaml
@@ -42,9 +42,10 @@ spec:
             description: 'Service reports having not enough pods to ensure High Availability'
         {{- end }}
 
+        {{- if and (gt (.Values.service.replicaCount | int) 0) (.Values.metrics.prometheusRule.defaultAlerts.zeroPods.enabled) }}
         - alert: ZeroPods-{{ include "motive-service.fullname" . }}
           expr: sum(kube_pod_status_ready{namespace="{{ $.Release.Namespace }}", pod=~"{{ include "motive-service.fullname" . }}-.+", condition="true"}) == 0
-          for: 0m
+          for: {{ .Values.metrics.prometheusRule.defaultAlerts.zeroPods.for }}
           labels:
             severity: critical
             {{- with $.Values.metrics.prometheusRule.defaultAlerts.team }}
@@ -59,6 +60,7 @@ spec:
           annotations:
             summary: 'Number of Pods == 0'
             description: 'Service reports no pods running'
+        {{- end }}
     # default alerts - END
 
     # Kafka default alerts - START

--- a/charts/motive-service/values.yaml
+++ b/charts/motive-service/values.yaml
@@ -541,6 +541,9 @@ metrics:
       slackChannelInfo: ""
       slackChannelWarning: ""
       slackChannelCritical: ""
+      zeroPods:
+        enabled: true
+        for: 0m
       kafka:
         enabled: false
         deadLetter:


### PR DESCRIPTION
This pull request updates both the `motive-cache` and `motive-service` Helm charts, primarily focusing on improving Prometheus alerting logic and incrementing chart versions. The most important changes are the conditional configuration of "Zero Pods" alerts based on replica counts and new values, as well as version bumps to reflect these updates.

**Prometheus alerting improvements:**

* In `motive-cache`, the "Zero Pods" alert is now only created if `.Values.replicas` is greater than zero, preventing unnecessary alerts when no replicas are expected. [[1]](diffhunk://#diff-f8c3d76fb2e4d24c5a4054007397465b23a82f0655eb46d8e027f65275be1491R45) [[2]](diffhunk://#diff-f8c3d76fb2e4d24c5a4054007397465b23a82f0655eb46d8e027f65275be1491R63)
* In `motive-service`, the "Zero Pods" alert is conditionally enabled based on both `.Values.service.replicaCount` and a new `.Values.metrics.prometheusRule.defaultAlerts.zeroPods.enabled` value, with the alert duration (`for`) now configurable via values. [[1]](diffhunk://#diff-fe093e33a3e94a65e3c2b73c018e9131c14f1ec8f8260131eaab90540bd5fd4bR45-R48) [[2]](diffhunk://#diff-fe093e33a3e94a65e3c2b73c018e9131c14f1ec8f8260131eaab90540bd5fd4bR63) [[3]](diffhunk://#diff-e5627af9d1bb0b46068419329b7d5735e016515d1609182e65c14adf254151d9R544-R546)

**Version updates:**

* Bumped `motive-cache` chart version from `0.1.8` to `0.1.9` in `Chart.yaml` and updated README badge [[1]](diffhunk://#diff-d767fe4099d390a1e5de5bff34cb7544b53cc44d22872f5430d0ef81e6b7b4deL7-R7) [[2]](diffhunk://#diff-868a4525e373786e225365affd3a7f69f33e4ba6c59478caaee69e4e5cf7c0f4L3-R3)
* Bumped `motive-service` chart version from `2.2.3` to `2.2.4` in `Chart.yaml` and updated README badge [[1]](diffhunk://#diff-0ac4a76178cd842a7a368e8940698523325e438408f6c7ca68e8fd3a767eb2c2L7-R7) [[2]](diffhunk://#diff-1fd14626e414396aa6b3ab66a63d4ab045f3fde4f21ac3a1c7b5b66df746366aL3-R3)