### PR TITLE
chore: Change cache zero pods alert level

### DIFF
--- a/charts/motive-cache/Chart.yaml
+++ b/charts/motive-cache/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.9
+version: 0.1.10
 
 appVersion: "1.0.0"

--- a/charts/motive-cache/templates/prometheus-rule-alerting.yaml
+++ b/charts/motive-cache/templates/prometheus-rule-alerting.yaml
@@ -47,7 +47,7 @@ spec:
           expr: sum(kube_pod_status_ready{namespace="{{ $.Release.Namespace }}", pod=~"{{ include "motive-cache.fullname" . }}-.+", condition="true"}) == 0
           for: 0m
           labels:
-            severity: critical
+            severity: warning
             {{- with $.Values.metrics.prometheusRule.defaultAlerts.team }}
             team: {{ . | quote }}
             {{- end }}


### PR DESCRIPTION
Change the alert level to warning, because a cache should improve the performance, but it should not cause errors.